### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,3 +29,10 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+// *** Ensure Gradle compiles with Java 17 no matter your local JDK ***
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}


### PR DESCRIPTION
Ensures Gradle compiles with Java 17 no matter the local JDK